### PR TITLE
Remove 1 GB server from flavors

### DIFF
--- a/parse.yaml
+++ b/parse.yaml
@@ -70,7 +70,6 @@ parameters:
     description: Flavor of Cloud Server to use
     constraints:
     - allowed_values:
-      - 1 GB General Purpose v1
       - 2 GB General Purpose v1
       - 4 GB General Purpose v1
       - 8 GB General Purpose v1


### PR DESCRIPTION
Building this with the 1 GB server results in out-of-memory errors:

dpkg: unrecoverable fatal error, aborting:
fork failed: Cannot allocate memory
E: Sub-process /usr/bin/dpkg returned an error code (2)

I saw the PM2 process using nearly 800 MB of RES memory.
